### PR TITLE
Cleanup Proxmox Module

### DIFF
--- a/modules/proxmox-vm/main.tf
+++ b/modules/proxmox-vm/main.tf
@@ -25,7 +25,7 @@ resource "proxmox_vm_qemu" "virtual_machines" {
   sshkeys = join("\r\n", var.ssh_keys)
 
   searchdomain = var.dns_zone
-  nameserver   = "1.1.1.1 8.8.8.8"
+  nameserver   = var.dns_server
 
   dynamic "disk" {
     for_each = try(length(each.value.storage), 0) > 0 ? each.value.storage : []

--- a/modules/proxmox-vm/main.tf
+++ b/modules/proxmox-vm/main.tf
@@ -25,7 +25,7 @@ resource "proxmox_vm_qemu" "virtual_machines" {
   sshkeys = join("\r\n", var.ssh_keys)
 
   searchdomain = var.dns_zone
-  nameserver   = var.dns_server
+  nameserver   = join(" ", var.dns_server)
 
   dynamic "disk" {
     for_each = try(length(each.value.storage), 0) > 0 ? each.value.storage : []

--- a/modules/proxmox-vm/variables.tf
+++ b/modules/proxmox-vm/variables.tf
@@ -21,7 +21,7 @@ variable "machines" {
     target_node = optional(string)
     pool        = optional(string)
     cores       = optional(number)
-    socket      = optional(number)
+    sockets     = optional(number)
     balloon     = optional(number)
     memory      = optional(number)
 
@@ -64,9 +64,9 @@ variable "dns_zone" {
 }
 
 variable "dns_servers" {
-  type        = string
+  type        = list(string)
   default     = ""
-  description = "Space delimited string of up to 3 DNS resolvers."
+  description = "list of up to 3 DNS resolvers."
 }
 
 variable "pm_api_url" {

--- a/modules/proxmox-vm/variables.tf
+++ b/modules/proxmox-vm/variables.tf
@@ -68,10 +68,11 @@ variable "dns_servers" {
   default     = []
   description = "List of up to 3 DNS resolvers."
 
-    validation {
-    condition     = can(regex("^(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$", var.dns_servers))
+  validation {
+    condition = alltrue([for server in var.dns_servers : can(regex("^(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$", server))])
     error_message = "Err: Invalid IP Address"
   }
+
   validation {
     condition     = length(var.dns_servers) <= 3
     error_message = "Err: cannot have more than 3 servers defined."

--- a/modules/proxmox-vm/variables.tf
+++ b/modules/proxmox-vm/variables.tf
@@ -69,7 +69,7 @@ variable "dns_servers" {
   description = "List of up to 3 DNS resolvers."
 
     validation {
-    condition     = can(regex("^(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$", var.dns_servers))
+    condition     = can(regex("^(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$", var.dns_servers))
     error_message = "Err: Invalid IP Address"
   }
   validation {

--- a/modules/proxmox-vm/variables.tf
+++ b/modules/proxmox-vm/variables.tf
@@ -65,8 +65,17 @@ variable "dns_zone" {
 
 variable "dns_servers" {
   type        = list(string)
-  default     = ""
-  description = "list of up to 3 DNS resolvers."
+  default     = []
+  description = "List of up to 3 DNS resolvers."
+
+    validation {
+    condition     = can(regex("^(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$", var.dns_servers))
+    error_message = "Err: Invalid IP Address"
+  }
+  validation {
+    condition     = length(var.dns_servers) <= 3
+    error_message = "Err: cannot have more than 3 servers defined."
+  }
 }
 
 variable "pm_api_url" {

--- a/modules/proxmox-vm/variables.tf
+++ b/modules/proxmox-vm/variables.tf
@@ -63,9 +63,15 @@ variable "dns_zone" {
   description = "Local DNS zone."
 }
 
+variable "dns_servers" {
+  type        = string
+  default     = ""
+  description = "Space delimited string of up to 3 DNS resolvers."
+}
+
 variable "pm_api_url" {
   type        = string
-  default     = "https://hv01:8006/api2/json"
+  default     = ""
   description = "Proxmox host."
 }
 

--- a/modules/proxmox-vm/version.tf
+++ b/modules/proxmox-vm/version.tf
@@ -19,11 +19,9 @@ provider "proxmox" {
 
   # api token id is in the form of: <username>@pam!<tokenId>
   pm_api_token_id = var.pm_api_token_id
-  #pm_api_token_id = "${env.pm_api_token_id}"
 
   # this is the full secret wrapped in quotes. don't worry, I've already deleted this from my proxmox cluster by the time you read this post
   pm_api_token_secret = var.pm_api_token_secret
-  #pm_api_token_secret = "${env.pm_api_token_secret}"
 
   # leave tls_insecure set to true unless you have your proxmox SSL certificate situation fully sorted out (if you do, you will know)
   pm_tls_insecure = true


### PR DESCRIPTION
Signed-off-by: David Hooton <djh00t@users.noreply.github.com>

- Remove user specific API URL from default variable value
- Move dns `nameserver` value into user defined `dns_servers` variable
- Remove redundant comments in version.tf

**Benefits**
Configuration lives entirely in user configurations

**Possible drawbacks**

- People who bill by the hour might bill less hours while using this module for clients.
- Configuration will have two additional (sensible) variables to provide.

**Applicable issues**
N/A

**Additional information**
N/A